### PR TITLE
Send out all dates in ISO 8601 format

### DIFF
--- a/src/app_factory.py
+++ b/src/app_factory.py
@@ -1,17 +1,21 @@
-from importlib import import_module
 import json
+from importlib import import_module
 
 from flask import Flask
 from werkzeug.exceptions import HTTPException
 
 import src.configuration as config
 from src.blueprints import all_blueprints
+from src.core.helpers.JsonEncode import JsonEncode
 from src.extensions import init_extensions
 
 
 def create_app():
     """Create an instance of the app."""
     app = Flask(__name__)
+
+    # Override the default JSON encoder with a customized one
+    app.json_encoder = JsonEncode
 
     # Load the app configuration
     app.config.update(config.get_app_config("default"))
@@ -35,10 +39,10 @@ def create_app():
         Copied from
         https://flask.palletsprojects.com/en/1.1.x/errorhandling/#generic-exception-handlers
         """
-        # start with the correct headers and status code from the error
+        # Start with the correct headers and status code from the error
         response = e.get_response()
 
-        # replace the body with JSON
+        # Replace the body with JSON
         response.data = json.dumps(
             {"code": e.code, "name": e.name, "description": e.description}
         )

--- a/src/core/helpers/JsonEncode.py
+++ b/src/core/helpers/JsonEncode.py
@@ -1,0 +1,15 @@
+from datetime import datetime
+from flask.json import JSONEncoder
+
+
+class JsonEncode(JSONEncoder):
+    """Override the default Flask JSONEncoder.
+    By default, Flask converts datetime objects to RFC 1123 dates.
+    Override this behavior to convert them to ISO 8601 format instead.
+    """
+
+    def default(self, o):
+        if isinstance(o, datetime):
+            return o.isoformat()
+
+        return super().default(o)

--- a/src/core/helpers/JsonEncode.py
+++ b/src/core/helpers/JsonEncode.py
@@ -11,5 +11,4 @@ class JsonEncode(JSONEncoder):
     def default(self, o):
         if isinstance(o, datetime):
             return o.isoformat()
-
         return super().default(o)

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,3 @@
+[flake8]
+max-line-length = 88
+extend-ignore = E203


### PR DESCRIPTION
Because this is easier to work with natively in Python and it's just n i c e r.