### PR TITLE
Revise host endpoint to respond with hosting dates more sanely

### DIFF
--- a/src/blueprints/v1/public/host.py
+++ b/src/blueprints/v1/public/host.py
@@ -54,7 +54,7 @@ def get(args: dict):
 @use_args({"handle": fields.String(required=True)}, location="json")
 def post(args: dict):
     """Create a new Host."""
-    if database.host.exists(uid="", handle=args["handle"]):
+    if database.host.exists(handle=args["handle"]):
         return helpers.make_error_response(
             422, f'Host {args["handle"]} already exists!'
         )
@@ -85,7 +85,7 @@ def post(args: dict):
 def patch(args: dict):
     """Update a Host's handle."""
     # Attempt to find the host. They must exist to be updated
-    existing_host = database.host.exists(uid=args["id"], handle="")
+    existing_host = database.host.exists(uid=args["id"])
     if not existing_host:
         return helpers.make_error_response(400, "Unable to update Host details!")
 

--- a/src/blueprints/v1/public/host.py
+++ b/src/blueprints/v1/public/host.py
@@ -145,8 +145,7 @@ def date_get(args: dict):
         if current_host:
             return helpers.make_response(200, jsonify(current_host))
         return helpers.make_error_response(
-            404,
-            f"Unable to get Host info for {helpers.format_datetime_ymd(args['date'])}!",
+            404, f"Unable to get Host for {helpers.format_datetime_ymd(args['date'])}!",
         )
 
 

--- a/src/blueprints/v1/public/host.py
+++ b/src/blueprints/v1/public/host.py
@@ -67,13 +67,13 @@ def post(args: dict):
         )
 
     # Create a host with all their details
-    args["id"] = host_id
+    args["uid"] = host_id
     result = database.host.create(args)
-    if result:
-        return helpers.make_response(201, args)
-    return helpers.make_error_response(
-        503, f'Unable to create new Host {args["handle"]}!'
-    )
+    if result is None:
+        return helpers.make_error_response(
+            503, f'Unable to create new Host {args["handle"]}!'
+        )
+    return helpers.make_response(201, result)
 
 
 @authorize_route

--- a/src/blueprints/v1/public/search.py
+++ b/src/blueprints/v1/public/search.py
@@ -45,7 +45,7 @@ def get(args: dict):
     """Search for a Prompt by word or Host."""
     # Both parameters were provided, and that is not supported
     if len(args) > 1:
-        return make_error_response(422, "Only on parameter can be provided!")
+        return make_error_response(422, "Only one parameter can be provided!")
 
     if "prompt" in args:
         return make_response(200, search_by_prompt(args["prompt"]))

--- a/src/blueprints/v1/public/search.py
+++ b/src/blueprints/v1/public/search.py
@@ -43,9 +43,9 @@ def search_by_host(handle: str) -> dict:
 )
 def get(args: dict):
     """Search for a Prompt by word or Host."""
-    # Both parameters were provided, and that is not supporte
+    # Both parameters were provided, and that is not supported
     if len(args) > 1:
-        return make_error_response(422, "Only one search parameter can be provided!")
+        return make_error_response(422, "Only on parameter can be provided!")
 
     if "prompt" in args:
         return make_response(200, search_by_prompt(args["prompt"]))

--- a/src/core/database/core.py
+++ b/src/core/database/core.py
@@ -2,11 +2,7 @@ import records
 from flask import current_app
 
 
-__all__ = [
-    "connect_to_db",
-    "create_transaction",
-    "flatten_tuple_list",
-]
+__all__ = ["connect_to_db", "create_transaction", "flatten_records"]
 
 
 def connect_to_db() -> records.Database:
@@ -26,6 +22,6 @@ def create_transaction(db):
     return db._engine.begin()  # skipcq: PYL-W0212
 
 
-def flatten_tuple_list(tup: tuple) -> list:
-    """Flatten a list of tuples into a tuple of actual data."""
+def flatten_records(tup: tuple) -> list:
+    """Flatten a nested list of records."""
     return [item[0] for item in tup]

--- a/src/core/database/host.py
+++ b/src/core/database/host.py
@@ -77,14 +77,14 @@ def delete_date(uid: str, date: str) -> Literal[True]:
     return True
 
 
-def exists(*, uid: str, handle: str) -> bool:
+def exists(*, uid: str = "", handle: str = "") -> bool:
     """Find an existing Host."""
     sql = "SELECT 1 FROM writers WHERE (uid = :uid OR handle = :handle)"
     with connect_to_db() as db:
         return bool(db.query(sql, uid=uid, handle=handle).first())
 
 
-def get(*, uid: str, handle: str) -> List[Host]:
+def get(*, uid: str = "", handle: str = "") -> List[Host]:
     """Get Host info by either their Twitter ID or handle."""
     sql = """
     SELECT writers.uid, handle, writer_dates.date

--- a/src/core/database/host.py
+++ b/src/core/database/host.py
@@ -81,24 +81,20 @@ def delete_date(uid: str, date: str) -> Literal[True]:
 
 def exists(*, uid: str = "", handle: str = "") -> bool:
     """Find an existing Host."""
-    sql = "SELECT 1 FROM writers WHERE (uid = :uid OR handle = :handle)"
+    sql = "SELECT 1 FROM writers WHERE uid = :uid OR handle = :handle"
     with connect_to_db() as db:
         return bool(db.query(sql, uid=uid, handle=handle).first())
 
 
-def get(*, uid: str = "", handle: str = "") -> List[Host]:
+def get(*, uid: str = "", handle: str = "") -> Host:
     """Get Host info by either their Twitter ID or handle."""
     sql = """
-    SELECT writers.uid, handle, writer_dates.date
+    SELECT writers.uid, handle
     FROM writers
-        JOIN writer_dates ON writer_dates.uid = writers.uid
-    WHERE
-        writer_dates.date <= CURRENT_TIMESTAMP() AND
-        (writers.uid = :uid OR UPPER(handle) = UPPER(:handle))
-    ORDER BY date DESC
+    WHERE writers.uid = :uid OR UPPER(handle) = UPPER(:handle)
     """
     with connect_to_db() as db:
-        return [Host(host) for host in db.query(sql, uid=uid, handle=handle)]
+        return Host(db.query(sql, uid=uid, handle=handle).one())
 
 
 def get_all() -> List[Host]:
@@ -112,22 +108,22 @@ def get_all() -> List[Host]:
         return [Host(host) for host in db.query(sql)]
 
 
-def get_by_date(date: str) -> List[Host]:
+def get_by_date(date: str) -> Host:
     """Get the Host for the given date."""
     sql = """
-    SELECT writers.uid, handle, writer_dates.date
+    SELECT writers.uid, handle
     FROM writers
         JOIN writer_dates ON writer_dates.uid = writers.uid
     WHERE writer_dates.date = :date
     """
     with connect_to_db() as db:
-        return [Host(host) for host in db.query(sql, date=date)]
+        return Host(db.query(sql, date=date).one())
 
 
 def get_by_year(year: str) -> List[Host]:
     """Get a list of all Hosts for a given year."""
     sql = """
-    SELECT writers.uid, handle, writer_dates.date
+    SELECT writers.uid, handle
     FROM writers
         JOIN writer_dates ON writer_dates.uid = writers.uid
     WHERE YEAR(writer_dates.date) = :year
@@ -142,7 +138,7 @@ def get_by_year(year: str) -> List[Host]:
 def get_by_year_month(year: str, month: str) -> List[Host]:
     """Get all the Hosts in a year-month combination."""
     sql = """
-    SELECT writers.uid, handle, writer_dates.date
+    SELECT writers.uid, handle
     FROM writers
         JOIN writer_dates ON writer_dates.uid = writers.uid
     WHERE

--- a/src/core/database/host.py
+++ b/src/core/database/host.py
@@ -1,5 +1,5 @@
 from datetime import datetime
-from typing import List, Literal, Union
+from typing import List, Literal, Optional, Union
 
 from tweepy.error import TweepError
 from sqlalchemy.exc import DataError, IntegrityError
@@ -26,16 +26,16 @@ __all__ = [
 ]
 
 
-def create(host_info: dict) -> bool:
+def create(host_info: dict) -> Optional[Host]:
     """Create a new Host."""
     sql = "INSERT INTO writers (uid, handle) VALUES (:uid, :handle)"
     try:
         with connect_to_db() as db:
-            db.query(sql, uid=host_info["id"], handle=host_info["handle"])
-        return True
+            db.query(sql, uid=host_info["uid"], handle=host_info["handle"])
+        return Host(host_info)
     except DataError as exc:
         print(exc)
-        return False
+        return None
 
 
 def create_date(host_info: dict) -> bool:

--- a/src/core/database/host.py
+++ b/src/core/database/host.py
@@ -1,3 +1,4 @@
+from datetime import datetime
 from typing import List, Literal, Union
 
 from tweepy.error import TweepError
@@ -14,12 +15,13 @@ __all__ = [
     "delete",
     "delete_date",
     "exists",
-    "lookup",
     "get",
     "get_all",
     "get_by_date",
     "get_by_year",
     "get_by_year_month",
+    "get_date",
+    "lookup",
     "update",
 ]
 
@@ -151,6 +153,24 @@ def get_by_year_month(year: str, month: str) -> List[Host]:
     """
     with connect_to_db() as db:
         return [Host(host) for host in db.query(sql, year=year, month=month)]
+
+
+def get_date(handle: str) -> List[datetime]:
+    """Get the hosting periods for the given Host."""
+    sql = """
+    SELECT date
+    FROM writer_dates
+    WHERE uid = (
+        SELECT uid FROM writers
+        WHERE handle = :handle
+    )
+    ORDER BY date DESC
+    """
+    with connect_to_db() as db:
+        return [
+            datetime.combine(record["date"], datetime.min.time())
+            for record in db.query(sql, handle=handle)
+        ]
 
 
 def lookup(handle: str) -> Union[str, Literal[False]]:

--- a/src/core/database/host.py
+++ b/src/core/database/host.py
@@ -43,7 +43,7 @@ def create_date(host_info: dict) -> bool:
     sql = """INSERT INTO writer_dates (
         uid, date
     ) VALUES (
-        :uid, STR_TO_DATE(:date, '%Y-%m-%d')
+        :uid, STR_TO_DATE(:date, '%Y-%m-%d 00:00:00')
     )"""
     try:
         with connect_to_db() as db:

--- a/src/core/database/host.py
+++ b/src/core/database/host.py
@@ -104,14 +104,12 @@ def get(*, uid: str = "", handle: str = "") -> List[Host]:
 def get_all() -> List[Host]:
     """Get a list of all Hosts."""
     sql = """
-    SELECT DISTINCT writers.uid, handle
+    SELECT writers.uid, handle
     FROM writers
-        JOIN writer_dates ON writer_dates.uid = writers.uid
-    WHERE writer_dates.date <= CURRENT_TIMESTAMP()
     ORDER BY handle
     """
     with connect_to_db() as db:
-        return db.query(sql).all(as_dict=True)
+        return [Host(host) for host in db.query(sql)]
 
 
 def get_by_date(date: str) -> List[Host]:

--- a/src/core/database/prompt.py
+++ b/src/core/database/prompt.py
@@ -2,7 +2,7 @@ from typing import Dict, List, Literal, Optional
 
 from sqlalchemy.exc import IntegrityError
 
-from src.core.database.core import connect_to_db, flatten_tuple_list
+from src.core.database.core import connect_to_db, flatten_records
 from src.core.models.v1.Prompt import Prompt
 
 __all__ = [
@@ -123,7 +123,7 @@ def get_years() -> List[str]:
     ORDER BY date ASC
     """
     with connect_to_db() as db:
-        return flatten_tuple_list(db.query(sql).all())
+        return flatten_records(db.query(sql).all())
 
 
 def search(word: str) -> List[Prompt]:

--- a/src/core/models/v1/Host.py
+++ b/src/core/models/v1/Host.py
@@ -1,5 +1,3 @@
-from datetime import datetime
-
 from records import Record
 
 
@@ -7,16 +5,10 @@ class Host(dict):
     def __init__(self, record: Record):
         self.id: str = record["uid"]
         self.handle: str = record["handle"]
-        self.date: datetime = datetime(
-            record["date"].year, record["date"].month, record["date"].day
-        )
-        self.url: str = str(self)
+        self.url: str = self.make_url(record["handle"])
 
         # Make the class JSON serializable
         super().__init__(self.__dict__)
-
-    def __str__(self):
-        return self.make_url(self.handle)
 
     @staticmethod
     def make_url(writer_handle: str) -> str:


### PR DESCRIPTION
Much as #38 cleaned up creating/deleting hosting dates, this cleans up fetching those dates.
- `Host` model had `date` attribute removed
- GET `host` no longer returns any form of date
- GET `host` no longer returns a list of `Host`s
- GET `host?all=true` now returns `Host` model
- POST `host` now returns `Host` model
- GET `host/date` now accepts `handle` param to get hosting dates for given Host handle
- Various internal cleanup